### PR TITLE
using guestfs_helper to wrap the kernel install

### DIFF
--- a/lib/boxgrinder-build/plugins/platform/ec2/ec2-plugin.rb
+++ b/lib/boxgrinder-build/plugins/platform/ec2/ec2-plugin.rb
@@ -45,7 +45,7 @@ module BoxGrinder
           # Remove normal kernel
           guestfs.sh("yum -y remove kernel")
           # because we need to install kernel-xen package
-          guestfs.sh("yum -y install kernel-xen")
+          guestfs_helper.sh("yum -y install kernel-xen", :arch => @appliance_config.hardware.arch)
           # and add require modules
           @linux_helper.recreate_kernel_image(guestfs, ['xenblk', 'xennet'])
         end


### PR DESCRIPTION
I've been trying to build a 32bit AMI from the 64bit meta-appliance.  The problem is that the ec2-plugin ignores that the user has used "setarch i686" to run boxgrinder-build.  This patch simply uses the guestfs_helper to launch the yum kernel-xen install instead of the direct guestfs.
