### PR TITLE
add scientific linux as valid OS in ebs delivery plugin

### DIFF
--- a/lib/boxgrinder-build/plugins/delivery/ebs/ebs-plugin.rb
+++ b/lib/boxgrinder-build/plugins/delivery/ebs/ebs-plugin.rb
@@ -73,6 +73,7 @@ module BoxGrinder
       register_supported_os('fedora', ['13', '14', '15', '16'])
       register_supported_os('rhel', ['6'])
       register_supported_os('centos', ['5', '6'])
+      register_supported_os('sl', ['5', '6'])
     end
 
     def execute

--- a/spec/plugins/delivery/ebs/ebs-plugin-spec.rb
+++ b/spec/plugins/delivery/ebs/ebs-plugin-spec.rb
@@ -75,10 +75,11 @@ module BoxGrinder
       supported_oses = @plugin.instance_variable_get(:@supported_oses)
 
       supported_oses.size.should == 3
-      Set.new(supported_oses.keys).should == Set.new(['fedora', 'rhel', 'centos'])
+      Set.new(supported_oses.keys).should == Set.new(['fedora', 'rhel', 'centos', 'sl'])
       supported_oses['rhel'].should == ['6']
       supported_oses['fedora'].should == ['13', '14', '15', '16']
       supported_oses['centos'].should == ['5', '6']
+      supported_oses['sl'].should == ['5', '6']
     end
 
     it "should adjust fstab" do


### PR DESCRIPTION
Delivery of Scientific Linux builds to EBS works fine if SL is added as a valid version to the version check in the plugin.
