### PR TITLE
Adds "kernel" package before removing "kernel-xen", so packages that rely on "kernel" won't get removed.

### DIFF
--- a/lib/boxgrinder-build/plugins/platform/ec2/ec2-plugin.rb
+++ b/lib/boxgrinder-build/plugins/platform/ec2/ec2-plugin.rb
@@ -49,10 +49,10 @@ module BoxGrinder
         @log.debug "'/etc/resolv.conf' uploaded."
 
         if (@appliance_config.os.name == 'rhel' or @appliance_config.os.name == 'centos') and @appliance_config.os.version == '5'
-          # Remove normal kernel
-          guestfs.sh("yum -y remove kernel")
-          # because we need to install kernel-xen package
+          # Install kernel-xen package
           guestfs_helper.sh("yum -y install kernel-xen", :arch => @appliance_config.hardware.arch)
+          # Then remove normal kernel.  We don't need it anymore.
+          guestfs.sh("yum -y remove kernel")
           # and add require modules
           @linux_helper.recreate_kernel_image(guestfs, ['xenblk', 'xennet'])
         end


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/BGBUILD-370
