### PR TITLE
Make dependency on bash explicit in qemu.wrapper

### DIFF
--- a/lib/boxgrinder-build/helpers/qemu.wrapper
+++ b/lib/boxgrinder-build/helpers/qemu.wrapper
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -u
 set -e
 


### PR DESCRIPTION
This shell script uses shell features (notably, arrays) which are bash-specific. On Ubuntu Precise and later, `/bin/sh` is dash, not bash, and so the script fails. Fix this by explicitly setting the shebang line to `/bin/bash`.
