### PR TITLE
[BGBUILD-372] Abort from rescue clause during build failures

### DIFF
--- a/bin/boxgrinder-build
+++ b/bin/boxgrinder-build
@@ -209,6 +209,7 @@ begin
       log.fatal "#{e.class}: #{e.message}. See the log file for detailed information."
       log.debug msg
     end
+    abort
   end
 rescue => e
   puts opts


### PR DESCRIPTION
If an exception is thrown during builds, boxgrinder-build does not abort, so a "0" exit code is returned. If a script is running boxgrinder-build, it is not possible to detect build failure by simple exit codes.

This patch just does an "abort" in the rescue loop, as is done in numerous other places in boxgrinder-build.
