### PR TITLE
Don't assume all numbers are float in boxgrinder-build CLI

### DIFF
--- a/bin/boxgrinder-build
+++ b/bin/boxgrinder-build
@@ -55,7 +55,7 @@ def validate_hash_option(options, name, value)
         v = true
       elsif v =~ /^(n|N|no|No|NO|false|False|FALSE|off|Off|OFF)$/
         v = false
-      elsif v =~ /^([-+]?([0-9][0-9_]*)?\.[0-9.]*([eE][-+][0-9]+)?)$/
+      elsif v =~ /^([-+]?([0-9][0-9_]*)?(\.[0-9]+)?([eE][-+][0-9]+)?)$/
         v = v.to_f
       end
 


### PR DESCRIPTION
While running `boxgrinder-build`, if you pass in some options like `--delivery-config host:1.1.1.1`, it will be evaluated as `@plugin_config['host'] = 1.1`. The expected result would be `@plugin_config['host'] = '1.1.1.1'`. This is due to a small bug in a regular expression used to convert strings into floats in the boxgrinder-build CLI interface.

The fix involves looking for sane numbers only, meaning:
- 1 is a number
- 1.1 is a number
- 1.1e+10 is a number
- 1.1.1 is a string

This patch ensures that at most one decimal is provided before float conversion happens.
