### PR TITLE
Recreate the RPM database conditionally by comparing RPM versions

### DIFF
--- a/lib/boxgrinder-build/plugins/os/rpm-based/rpm-based-os-plugin.rb
+++ b/lib/boxgrinder-build/plugins/os/rpm-based/rpm-based-os-plugin.rb
@@ -92,7 +92,12 @@ module BoxGrinder
         guestfs.sh("chkconfig firstboot off") if guestfs.exists('/etc/init.d/firstboot') != 0
 
         # https://issues.jboss.org/browse/BGBUILD-148
-        recreate_rpm_database(guestfs, guestfs_helper) if @config.os.name != @appliance_config.os.name or @config.os.version != @appliance_config.os.version
+        guest_rpmversion = guestfs.sh("rpm --version").split.last
+        host_rpmversion = @exec_helper.execute("rpm --version").split.last
+        if guest_rpmversion != host_rpmversion
+          @log.debug "Guest RPM version (#{guest_rpmversion}) is different than the host (#{host_rpmversion})"
+          recreate_rpm_database(guestfs, guestfs_helper)
+        end
 
         execute_post(guestfs_helper)
 


### PR DESCRIPTION
Recreating the RPM database can be extremely time consuming. Since that is the case, it would be good to only run the recreation when absolutely necessary. The version of RPM does not necessarily change with each OS version. The only true comparison one can do to verify the need to recreate the RPM database is to compare the version of RPM running on the host operating system against the version of RPM running on the guest operating system. This patch does so using `rpm --version` on both the host and guest.
