### PR TITLE
Impossible to overwrite default plugin config values with false

### DIFF
--- a/lib/boxgrinder-build/plugins/base-plugin.rb
+++ b/lib/boxgrinder-build/plugins/base-plugin.rb
@@ -206,7 +206,7 @@ module BoxGrinder
       if block_given? && !(@plugin_config[key].nil?)
         @plugin_config[key] = yield(key, default_value, @plugin_config[key])
       else
-        @plugin_config[key] ||= default_value
+        @plugin_config[key] = default_value if @plugin_config[key].nil?
       end
     end
 

--- a/spec/plugins/base-plugin-spec.rb
+++ b/spec/plugins/base-plugin-spec.rb
@@ -188,6 +188,13 @@ module BoxGrinder
       @plugin.instance_variable_get(:@plugin_config)['key'].should == 'avalue'
     end
 
+    it "should not be overwritten by default value assignment"
+      @plugin.instance_variable_set(:@plugin_config, {'key' => false})
+      @plugin.set_default_config_value('key', true)
+
+      @plugin.instance_variable_get(:@plugin_config)['key'].should == false
+    end
+
     describe ".read_plugin_config" do
       it "should read plugin config" do
         plugins = mock('Plugins')

--- a/spec/plugins/base-plugin-spec.rb
+++ b/spec/plugins/base-plugin-spec.rb
@@ -188,7 +188,7 @@ module BoxGrinder
       @plugin.instance_variable_get(:@plugin_config)['key'].should == 'avalue'
     end
 
-    it "should not be overwritten by default value assignment"
+    it "should not be overwritten by default value assignment" do
       @plugin.instance_variable_set(:@plugin_config, {'key' => false})
       @plugin.set_default_config_value('key', true)
 


### PR DESCRIPTION
Default plugin parameter values may not be overwritten by boolean `false`. This is due to the `||=` assignment operator in ruby. By definition: The value of x will be replaced, but only if x is `nil` or `false`. This presents a problem when you want to disable some feature. I found it while trying to disable packaging on the local delivery plugin. Test included.
